### PR TITLE
Updated to support EF6-RC1 reorganization

### DIFF
--- a/Src/Agent.EntityFramework.Test/Agent.EntityFramework.Test.csproj
+++ b/Src/Agent.EntityFramework.Test/Agent.EntityFramework.Test.csproj
@@ -38,10 +38,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework">
-      <HintPath>..\..\packages\EntityFramework.6.0.0-beta1-20528\lib\net40\EntityFramework.dll</HintPath>
+      <HintPath>..\..\packages\EntityFramework.6.0.0-rc1-20726\lib\net40\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\..\packages\EntityFramework.6.0.0-beta1-20528\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>..\..\packages\EntityFramework.6.0.0-rc1-20726\lib\net40\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Gibraltar.Agent, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ca42a1ee8d2e42d3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -53,7 +53,6 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Data.Entity" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
     <Reference Include="System.Xml" />

--- a/Src/Agent.EntityFramework.Test/packages.config
+++ b/Src/Agent.EntityFramework.Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.0.0-beta1-20528" targetFramework="net40" />
+  <package id="EntityFramework" version="6.0.0-rc1-20726" targetFramework="net40" />
   <package id="Gibraltar.Agent" version="3.5.2.1521" targetFramework="net40" />
 </packages>

--- a/src/Agent.EntityFramework/Agent.EntityFramework.csproj
+++ b/src/Agent.EntityFramework/Agent.EntityFramework.csproj
@@ -39,9 +39,11 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\EntityFramework.6.0.0-beta1-20528\lib\net40\EntityFramework.dll</HintPath>
+    <Reference Include="EntityFramework">
+      <HintPath>..\..\packages\EntityFramework.6.0.0-rc1-20726\lib\net40\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer">
+      <HintPath>..\..\packages\EntityFramework.6.0.0-rc1-20726\lib\net40\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Gibraltar.Agent, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ca42a1ee8d2e42d3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Agent.EntityFramework/LoupeCommandInterceptor.cs
+++ b/src/Agent.EntityFramework/LoupeCommandInterceptor.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Data.Entity;
-using System.Data.Entity.Infrastructure;
+using System.Data.Entity.Infrastructure.Interception;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
@@ -59,7 +59,7 @@ namespace Gibraltar.Agent.EntityFramework
                     return;
 
                 s_IsRegistered = true;
-                Interception.AddInterceptor(new LoupeCommandInterceptor());
+                DbInterception.Add(new LoupeCommandInterceptor());
             }
         }
 
@@ -147,7 +147,6 @@ namespace Gibraltar.Agent.EntityFramework
         {
             StopTrackingCommand(command, interceptionContext, null);
         }
-
 
         private void StartTrackingContext(DbCommandInterceptionContext context)
         {
@@ -302,7 +301,7 @@ namespace Gibraltar.Agent.EntityFramework
             }
         }
 
-        private void StopTrackingCommand(DbCommand command, DbCommandInterceptionContext context, int? result)
+        private void StopTrackingCommand<T>(DbCommand command, DbCommandInterceptionContext<T> context, int? result)
         {
             string paramString = null;
 

--- a/src/Agent.EntityFramework/packages.config
+++ b/src/Agent.EntityFramework/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.0.0-beta1-20528" targetFramework="net40" />
+  <package id="EntityFramework" version="6.0.0-rc1-20726" targetFramework="net40" />
   <package id="Gibraltar.Agent" version="3.5.2.1521" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
The interception stuff was moved into its own namespace between beta and release candidate. This just fixes the method signatures and updates the package definitions.
